### PR TITLE
Endpoint for Device Info

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,11 +16,11 @@ qrcodegen = { version =  "1.8.0" }
 ring = { version = "0.16.20" }
 rocket = { version = "0.5.0-rc.2", features = ["json", "uuid"] }
 rocket_okapi = { version = "0.8.0-rc.2", features = ["rapidoc", "swagger", "uuid"] }
-schemars = { version = "0.8.11" }
+schemars = { version = "0.8.11", features = ["uuid1"] }
 serde = { version = "1.0.147", features = ["derive"] }
 serde_json = { version = "1.0.89" }
 sysinfo = { version = "0.27.0" }
-uuid = { version = "1.2.2", features = [ "serde" ] }
+uuid = { version = "1.2.2", features = ["serde"] }
 
 [dev-dependencies]
 assert_cmd = { version = "2.0.6" }

--- a/src/bin/mobile_api_server/api_v1.rs
+++ b/src/bin/mobile_api_server/api_v1.rs
@@ -14,6 +14,7 @@ pub mod tests_common;
 /// implementations.
 pub fn routes() -> Vec<rocket::Route> {
     openapi_get_routes![
+        device::info,
         device::status,
         device::get_config,
         device::set_config,


### PR DESCRIPTION
This commit adds a new endpoint to allow clients to query device information. Device information contains the product name and UUID.

Unlike other endpoints, the added endpoint has been made available without an API key. This way, client applications can check UUID and then use the appropriate API key from their internal database to access other endpoints from the server.